### PR TITLE
Replace deprecated term 'ESIPs' with 'ESIP Partner Organization'

### DIFF
--- a/Deprecated Docs/Bylaws.md
+++ b/Deprecated Docs/Bylaws.md
@@ -8,64 +8,64 @@ Partnership (Constitution Article III)
 >
 Section 1 – General
 >
-I.1.1 All ESIPs shall abide by the Constitution and Bylaws.
+I.1.1 All ESIP Partner Organizations shall abide by the Constitution and Bylaws.
 >
-I.1.2 All ESIPs have the right to participate in all Standing
+I.1.2 All ESIP Partner Organizations have the right to participate in all Standing
 Committees and Working Groups.
 >
 Section 2 – Data and Information Distributors
 >
-I.2.1 Category 1 ESIPs shall be primarily stewards of Earth science
+I.2.1 Category 1 ESIP Partner Organizations shall be primarily stewards of Earth science
 and related data sets or its supporting information, as well as providers of standardized products derived from those data.
 >
-I.2.2 Each Category 1 ESIP must designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
+I.2.2 Each Category 1 ESIP Partner Organization must designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
 >
-I.2.3 Category 1 ESIPs, as a group, must elect representatives to serve on each of the following Committees: Executive Committee, Constitution and Bylaws Committee, Partnership Committee, and Finance and Appropriations Committee.
+I.2.3 Category 1 ESIP Partner Organizations, as a group, must elect representatives to serve on each of the following Committees: Executive Committee, Constitution and Bylaws Committee, Partnership Committee, and Finance and Appropriations Committee.
 >
 Section 3 – Product and Service Providers
 >
-I.3.1 Category 2 ESIPs shall be engaged principally in the scientific development, provision, and support of data and information products, technology, or services aimed primarily at the Earth science and research communities.
+I.3.1 Category 2 ESIP Partner Organizations shall be engaged principally in the scientific development, provision, and support of data and information products, technology, or services aimed primarily at the Earth science and research communities.
 >
-I.3.2 Each Category 2 ESIP must designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
+I.3.2 Each Category 2 ESIP Partner Organization must designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
 >
-I.3.3 Category 2 ESIPs, as a group, must elect representatives to serve on each of the following Committees: Executive Committee, Constitution and Bylaws Committee, Partnership Committee, and Finance and Appropriations Committee.
+I.3.3 Category 2 ESIP Partner Organizations, as a group, must elect representatives to serve on each of the following Committees: Executive Committee, Constitution and Bylaws Committee, Partnership Committee, and Finance and Appropriations Committee.
 >
 Section 4 – Earth Science Application Providers
 >
-I.4.1 Category 3 ESIPs shall be engaged principally in the development, use or dissemination of Earth science information and applications for the purpose of commercial use, decision support, outreach, advocacy, or education.
+I.4.1 Category 3 ESIP Partner Organizations shall be engaged principally in the development, use or dissemination of Earth science information and applications for the purpose of commercial use, decision support, outreach, advocacy, or education.
 >
-I.4.2 Each Category 3 ESIP must designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
+I.4.2 Each Category 3 ESIP Partner Organization must designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
 >
-I.4.3. Category 3 ESIPs, as a group, must elect representatives to                                                   serve on each of the following Committees: Executive Committee, Constitution and Bylaws Committee, Partnership Committee, and Finance and Appropriations Committee.
+I.4.3. Category 3 ESIP Partner Organizations, as a group, must elect representatives to                                                   serve on each of the following Committees: Executive Committee, Constitution and Bylaws Committee, Partnership Committee, and Finance and Appropriations Committee.
 >
 Section 5 – ESIP Federation Sponsors
 >
-I.5.1 Category 4 ESIPs shall be major financial or in-kind supporters of ESIP Federation activities.
+I.5.1 Category 4 ESIP Partner Organizations shall be major financial or in-kind supporters of ESIP Federation activities.
 >
-I.5.2 Each Category 4 ESIP shall have the right to designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
+I.5.2 Each Category 4 ESIP Partner Organization shall have the right to designate one Representative to the Assembly by submitting the name to the Chair of the Constitution and Bylaws Committee.
 >
-I.5.3 Each Category 4 ESIP may send one representative as a non-voting member to Executive Committee and Finance and Appropriations Committee meetings.
+I.5.3 Each Category 4 ESIP Partner Organization may send one representative as a non-voting member to Executive Committee and Finance and Appropriations Committee meetings.
 >
 Section 6 – ESIP Federation Supporters
 >
-I.6.1 Category 5 ESIPs shall be non-voting financial or in-kind supporters of ESIP Federation activities.
+I.6.1 Category 5 ESIP Partner Organizations shall be non-voting financial or in-kind supporters of ESIP Federation activities.
 >
 Section 7 – Ending a Partnership
 >
-I.7.1 Any ESIP may leave the ESIP Federation voluntarily by submitting a letter of resignation to the Chair of the Partnership Committee.
+I.7.1 Any ESIP Partner Organization may leave the ESIP Federation voluntarily by submitting a letter of resignation to the Chair of the Partnership Committee.
 >
-I.7.2 Any ESIP may be designated as Inactive by the Partnership Committee under the following conditions: 
-(1) The ESIP has not attended a General Assembly meeting, nor designated a proxy, for a period of four (4) consecutive meetings; and,
-(2)    By the discretion of the Partnership Committee for any unusual circumstances. A review of this action by the Executive Committee can be requested by the affected ESIP. In this case, a majority vote by the Executive Committee is binding.
-(3)    Inactive status may be designated by the Partnership Committee to any ESIP that meets the above criteria retroactively when this bylaw comes into effect.
+I.7.2 Any ESIP Partner Organization may be designated as Inactive by the Partnership Committee under the following conditions: 
+(1) The ESIP Partner Organization has not attended a General Assembly meeting, nor designated a proxy, for a period of four (4) consecutive meetings; and,
+(2)    By the discretion of the Partnership Committee for any unusual circumstances. A review of this action by the Executive Committee can be requested by the affected ESIP Partner Organization. In this case, a majority vote by the Executive Committee is binding.
+(3)    Inactive status may be designated by the Partnership Committee to any ESIP Partner Organization that meets the above criteria retroactively when this bylaw comes into effect.
 >
-I.7.3    Any ESIP designated by the Partnership Committee as Inactive shall be notified by email or other means of their status. A good faith effort must be made to contact the ESIP to notify them of their change in status.
+I.7.3    Any ESIP Partner Organization designated by the Partnership Committee as Inactive shall be notified by email or other means of their status. A good faith effort must be made to contact the ESIP Partner Organization to notify them of their change in status.
 >
-I.7.4   Any ESIP designated as Inactive may be restored to Active status by resuming participation in the business of the Federation through attending a General Assembly meeting directly or by proxy, and/or a petition to the Partnership Committee stating reasons for inactivity.
+I.7.4   Any ESIP Partner Organization designated as Inactive may be restored to Active status by resuming participation in the business of the Federation through attending a General Assembly meeting directly or by proxy, and/or a petition to the Partnership Committee stating reasons for inactivity.
 >
-I.7.5    If an Inactive ESIP does not restore to Active status after a period of one (1) year from the date of their notification, the ESIP concerned may be removed from the ESIP Federation by a majority vote of the Partnership Committee. After removal, application as a new ESIP to the Partnership Committee must be made.
+I.7.5    If an Inactive ESIP Partner Organization does not restore to Active status after a period of one (1) year from the date of their notification, the ESIP Partner Organization concerned may be removed from the ESIP Federation by a majority vote of the Partnership Committee. After removal, application as a new ESIP Partner Organization to the Partnership Committee must be made.
 >
-I.7.6 Any ESIP may be removed from the ESIP Federation for conduct that in any way tends to substantially injure the ESIP Federation or to affect adversely its reputation, or that is destructive to the ESIP Federation’s goals and activities. Any Representative to the Assembly may recommend removal of any ESIP to the Chair of the Partnership Committee. The Partnership Committee will notify the ESIP concerned and ask for comment in its defense. The Partnership Committee will then consider the recommendation and, if approved, will present its recommendation for removal with the comments from the concerned ESIP in writing to the Chair of the Constitution and Bylaws Committee.  The Constitution and Bylaws Committee will then petition the Representatives. If the recommendation for removal receives approval by two-thirds of the Representatives, the ESIP concerned will be removed from the ESIP Federation.
+I.7.6 Any ESIP Partner Organization may be removed from the ESIP Federation for conduct that in any way tends to substantially injure the ESIP Federation or to affect adversely its reputation, or that is destructive to the ESIP Federation’s goals and activities. Any Representative to the Assembly may recommend removal of any ESIP Partner Organization to the Chair of the Partnership Committee. The Partnership Committee will notify the ESIP concerned and ask for comment in its defense. The Partnership Committee will then consider the recommendation and, if approved, will present its recommendation for removal with the comments from the concerned ESIP in writing to the Chair of the Constitution and Bylaws Committee.  The Constitution and Bylaws Committee will then petition the Representatives. If the recommendation for removal receives approval by two-thirds of the Representatives, the ESIP concerned will be removed from the ESIP Federation.
 >
 BYLAW II
 Assembly
@@ -77,7 +77,7 @@ II.1.1 Each Annual Meeting of the Assembly shall be called by the Executive Comm
 >
 II.1.2 Additional meetings of the Assembly may be called by the Executive Committee at least thirty days prior to the meeting.
 >
-II.1.3 Additional meetings may also be called if at least half of the ESIPs petition the Executive Committee to call a meeting.
+II.1.3 Additional meetings may also be called if at least half of the ESIP Partner Organizations petition the Executive Committee to call a meeting.
 >
 II.1.4 Participation in an Assembly meeting can be through distance methods.
 >
@@ -95,7 +95,7 @@ II.2.5 In the case of resolutions brought up during meetings of the Assembly, pa
 >
 II.2.6 Resolutions also may be passed using distance methods if the resolution receives approval by a simple majority of the entire Assembly. All elections carried out via distance methods shall include a closing date after which votes will no longer be accepted.
 >
-II.2.7 Any resolution imposing a binding requirement on any ESIP shall require a two-thirds approval vote of the Assembly for passage.
+II.2.7 Any resolution imposing a binding requirement on any ESIP Partner Organization shall require a two-thirds approval vote of the Assembly for passage.
 >
 Section 3 – Elections
 >
@@ -172,7 +172,7 @@ IV.2.5 [RESERVED]
 IV.2.6 The Executive Committee shall report on its activities at each meeting of the Assembly.
 >
 IV.2.7 The Executive Committee shall ensure that mechanisms are
-provided for notifying all ESIPs of official ESIP Federation business.
+provided for notifying all ESIP Partner Organizations of official ESIP Federation business.
 >
 Section 3 – Constitution and Bylaws Committee
 >
@@ -190,7 +190,7 @@ IV.4.4 Proposals for the expenditure of ESIP Federation financial resources shal
 >
 IV.4.5 Upon receipt of a proposal, the Finance and Appropriations Committee will promptly notify the Assembly that proposals are under review. The Finance and Appropriations Committee will assure that appropriate, timely reviews of the proposals are carried out and then forward its recommendations to the Executive Committee for further review. If the Executive Committee also recommends funding, appropriate actions will be taken to allocate the funds. Alternatively, the Finance and Appropriations Committee may submit proposals to the Assembly for review. If a resolution of the Assembly recommends funding, appropriate actions will be taken to allocate the funds.
 >
-IV.4.6 Category 4 ESIPs, as a group, may send one representative as a non-voting observer to Finance and Appropriations Committee meetings.
+IV.4.6 Category 4 ESIP Partner Organizations, as a group, may send one representative as a non-voting observer to Finance and Appropriations Committee meetings.
 >
 IV.4.7 The Finance and Appropriations Committee will report on its actions at each Meeting of the Assembly and submit an Annual Finance Report and Proposed Budget for the coming year at each Annual Meeting of the Assembly.
 >
@@ -219,7 +219,7 @@ V.1.1 Standing Committees are created by amendment of the Bylaws to include a ne
 >
 V.1.2 Each Standing Committee shall have a Chair elected by simple majority of a secret ballot of the Assembly. Each Standing Committees shall have a Vice Chair elected by a simple majority of the members of the Committee.
 >
-V.1.3 Standing Committees shall each year hold at least one physical meeting. All ESIPs will be notified not less than four weeks in advance of the meeting date.
+V.1.3 Standing Committees shall each year hold at least one physical meeting. All ESIP Partner Organizations will be notified not less than four weeks in advance of the meeting date.
 >
 V.1.4 Standing Committees shall report program and/or project activity to the Federation at least quarterly.
 >
@@ -300,12 +300,12 @@ VI.1.1 Working Groups are created by resolution of the Assembly or by simple maj
 >
 VI.1.2 Each Working Group shall have a Chair elected by a simple majority of the Assembly or Committee that created the Working Group .
 >
-VI.1.3 All ESIPs will be notified promptly by the Assembly or
+VI.1.3 All ESIP Partner Organizations will be notified promptly by the Assembly or
 Committee that created the Working Group of the Working Group’s goals, activities, and expected duration.
 >
-VI.1.4 Individuals from all ESIPs and from outside the Federation will be allowed to participate in any Working Group. However, only the designated ESIP Representative as described in Bylaw I can vote.
+VI.1.4 Individuals from all ESIP Partner Organizations and from outside the Federation will be allowed to participate in any Working Group. However, only the designated ESIP Representative as described in Bylaw I can vote.
 >
-VI.1.5 Due notice of all Working Group meetings and teleconferences shall be given to all ESIPs.
+VI.1.5 Due notice of all Working Group meetings and teleconferences shall be given to all ESIP Partner Organizations.
 >
 VI.1.6 Working Groups may be required to report on their activities at each meeting of the Assembly, in a form agreed by the Assembly.
 >

--- a/Deprecated Docs/Constitution.md
+++ b/Deprecated Docs/Constitution.md
@@ -33,26 +33,26 @@ Information Partners,** hereafter called the ESIP Federation.
 
  - III.1.1 Any entity engaged in activities pursuant to the goals and
 objectives of the ESIP Federation shall be eligible to join.
-Specifically, ESIP Federation Partners (ESIPs) will be expected to
+Specifically, ESIP Partner Organizations will be expected to
 contribute substantively to the provision of improved products and
-services based on Earth science. ESIP contributions and expertise will include, but will not necessarily be limited to, one or more of the following activities: archiving and distributing remotely sensed and ground based data; the scientific development, provision, and support of data and information products and services; and the development of Earth science applications. In addition, ESIPs may include major financial or in-kind supporters of the ESIP Federation’s activities.
+services based on Earth science. ESIP contributions and expertise will include, but will not necessarily be limited to, one or more of the following activities: archiving and distributing remotely sensed and ground based data; the scientific development, provision, and support of data and information products and services; and the development of Earth science applications. In addition, ESIP Partner Organizations may include major financial or in-kind supporters of the ESIP Federation’s activities.
 
 **Section 2 – ESIP Categories** 
 
- - III.2.1  There may be multiple categories of ESIPs, whose defining characteristics are as described in the Bylaws.
- - III.2.2  Each category of ESIP shall have rights and obligations defined in the Bylaws.  
- - III.2.3  New categories of ESIP may be defined upon recommendation of the Partnership Administrative Committee and upon receiving approval by two-thirds of the entire ESIP Federation Assembly.  
+ - III.2.1  There may be multiple categories of ESIP Partner Organizations, whose defining characteristics are as described in the Bylaws.
+ - III.2.2  Each category of ESIP Partner Organization shall have rights and obligations defined in the Bylaws.  
+ - III.2.3  New categories of ESIP Partner Organization may be defined upon recommendation of the Partnership Administrative Committee and upon receiving approval by two-thirds of the entire ESIP Federation Assembly.  
  - III.2.4  Existing Partnership categories may be dropped or modified upon recommendation of the Partnership Committee and upon receiving approval by two-thirds of the entire ESIP Federation Assembly.  
 
-**Section 3 – New ESIPs**
+**Section 3 – New ESIP Partner Organizations**
 
- - III.3.1 New ESIPs may be added to each ESIP category upon application to the Partnership Committee (see Article VI), review and presentation by the Partnership Committee of candidate qualifications to the ESIPFederation Assembly (see Article IV), and upon receipt of approval by two-thirds vote of the entire ESIP Federation Assembly.
+ - III.3.1 New ESIP Partner Organizations may be added to each ESIP category upon application to the Partnership Committee (see Article VI), review and presentation by the Partnership Committee of candidate qualifications to the ESIP Federation Assembly (see Article IV), and upon receipt of approval by two-thirds vote of the entire ESIP Federation Assembly.
 
 **Section 4 – Ending a Partnership**
 
-- III.4.1  Any ESIP may leave the ESIP Federation voluntarily by the
+- III.4.1  Any ESIP Partner Organization may leave the ESIP Federation voluntarily by the
 process defined in the Bylaws.  
-- III.4.2  Any ESIP may be removed from the ESIP Federation for conduct that in any way tends to substantially injure the ESIP Federation or to affect adversely its reputation, or that is destructive of the ESIP Federation’s goals and objectives. No ESIP shall be removed except after opportunity to be heard as provided in the Bylaws and upon receiving a two-thirds vote for termination by the entire ESIP Federation Assembly.
+- III.4.2  Any ESIP Partner Organization may be removed from the ESIP Federation for conduct that in any way tends to substantially injure the ESIP Federation or to affect adversely its reputation, or that is destructive of the ESIP Federation’s goals and objectives. No ESIP Partner Organization shall be removed except after opportunity to be heard as provided in the Bylaws and upon receiving a two-thirds vote for termination by the entire ESIP Federation Assembly.
  
 
 **ARTICLE IV**
@@ -140,7 +140,7 @@ Committees, Working Groups, and Clusters may not be represented as those of the 
 
 -   VII.2.1  Standing Committees shall champion and carry out the four central activities of the ESIP Federation (Article II) as explicated in the Bylaws.  
 -   VII.2.2  Participation in a Standing Committee shall be open to
-any ESIP.  
+any ESIP Partner Organization.  
 -   VII.2.3  Standing Committees shall operate and be regulated as
 provided for in the Bylaws.  
 
@@ -149,7 +149,7 @@ provided for in the Bylaws.  
 -   VII.3.1  ESIP Federation Working Groups may be created only by the Assembly or one of its Committees.  
 -   VII.3.2  Working Groups shall have a specified task to perform and
 shall have a finite duration.  
--   VII.3.3  Participation in Working Groups is open to any ESIP.  
+-   VII.3.3  Participation in Working Groups is open to any ESIP Partner Organization.  
 -   VII.3.4  Further duties and responsibilities of Working Groups shall
 be as provided in the Bylaws.  
 

--- a/ESIP Policies and Procedures/1.0 Corporate/ESIP P&P 1.3 Corporate Organization.md
+++ b/ESIP Policies and Procedures/1.0 Corporate/ESIP P&P 1.3 Corporate Organization.md
@@ -94,7 +94,7 @@ Section 3 -- Program Committee
 
 3.5 The Program Committee shall report on its activities at each meeting of the Assembly.
 
-3.6 The Program Committee shall ensure that mechanisms are provided for notifying all ESIPs of official ESIP business.
+3.6 The Program Committee shall ensure that mechanisms are provided for notifying all ESIP Partner Organizations of official ESIP business.
 
 Section 4 -- Assembly Meetings
 ------------------------------
@@ -136,7 +136,7 @@ Section 5 -- Administrative Committees
 
 5.3.5 Upon receipt of a proposal, the Finance Committee will promptly notify the Assembly that proposals are under review. The Finance Committee will assure that appropriate, timely reviews of the proposals are carried out and then forward its recommendations to the Program Committee for further review. If the Program Committee also recommends funding, appropriate actions will be taken to allocate the funds upon approval by the Board. Alternatively, the Finance Committee may submit proposals to the Board for review. If the Board recommends funding, appropriate actions will be taken to allocate the funds.
 
-5.3.6 Category 4 ESIPs, as a group, may send one representative as a non-voting observer to Finance Committee meetings.
+5.3.6 Category 4 ESIP Partner Organizations, as a group, may send one representative as a non-voting observer to Finance Committee meetings.
 
 5.3.7 The Finance Committee will report on its actions at each Meeting of the Assembly and submit an Annual Finance Report and Proposed Budget for the coming year at each Annual Meeting of the Assembly.
 
@@ -181,7 +181,7 @@ Section 6 -- Standing Committees, Working Groups and Clusters
 
 6.1.2 Each Standing Committee shall have a Chair elected by simple majority of a secret ballot of the Assembly. Each Standing Committees shall have a Vice Chair elected by a simple majority of the members of the Committee.
 
-6.1.3 Standing Committees shall each year hold at least one meeting. All ESIPs will be notified not less than four weeks in advance of the meeting date.
+6.1.3 Standing Committees shall each year hold at least one meeting. All ESIP Partner Organizations will be notified not less than four weeks in advance of the meeting date.
 
 6.1.4 Standing Committees shall report program and/or project activity to the Assembly at least quarterly.
 
@@ -252,11 +252,11 @@ Section 7 -- Working Groups
 
 7.1.2 Each Working Group shall have a Chair elected by a simple majority of the Assembly or Committee that created the Working Group.
 
-7.1.3 All ESIPs will be notified promptly by the Assembly or Committee that created the Working Group of the Working Group's goals, activities, and expected duration.
+7.1.3 All ESIP Partner Organizations will be notified promptly by the Assembly or Committee that created the Working Group of the Working Group's goals, activities, and expected duration.
 
-7.1.4 Individuals from all ESIPs and from outside will be allowed to participate in any Working Group. However, only the designated ESIP Representative as described in Bylaw I can vote.
+7.1.4 Individuals from all ESIP Partner Organizations and from outside will be allowed to participate in any Working Group. However, only the designated ESIP Representative as described in Bylaw I can vote.
 
-7.1.5 Due notice of all Working Group meetings and teleconferences shall be given to all ESIPs.
+7.1.5 Due notice of all Working Group meetings and teleconferences shall be given to all ESIP Partner Organizations.
 
 7.1.6 In the event that the elected Chair of a Working Group is unable to continue to execute the duties of that office, the Executive Committee shall appoint an eligible replacement to serve out the remainder of that term.
 


### PR DESCRIPTION
# Problem
The governance documents are filled with references to partner organizations using the deprecated term _ESIPs_

Solves #10 

# Approach
In some, more modern sections of the documents, the term used is _ESIP Partner Organizations_ - I used this specific term to replace all references to _ESIPs_

# Note
There is a folder of "deprecated docs" - I updated these as well. I'm not sure if that really should be included in this