### PR TITLE
Winter/summer P&P terms

### DIFF
--- a/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.3F Federation Committee Budget Request Policy.md
+++ b/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.3F Federation Committee Budget Request Policy.md
@@ -72,7 +72,7 @@
      will submit required reports to the Executive Committee.
     
     a.   Reports will be submitted semi-annually, 30 days prior to the
-         Winter and Summer meetings.
+         January and July meetings.
     
     b.   Reports will document milestones, money spent, and finished
          products,as appropriate.

--- a/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.5A Travel and Expense Reimbursement Policy.md
+++ b/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.5A Travel and Expense Reimbursement Policy.md
@@ -10,7 +10,7 @@ leading or supporting relevant activities.
 
 If they so desire and have no other funding mechanism to support this,
 Program Committee and ESIP Board members will receive *de facto* support
-to attend the ESIP Winter and Summer Meetings. In addition, ESIP
+to attend the ESIP January and July Meetings. In addition, ESIP
 provides travel to the Student Fellows, FUNDing Friday winners according
 to their positions.
 

--- a/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.5B Complimentary Registration Fee Policy.md
+++ b/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.5B Complimentary Registration Fee Policy.md
@@ -3,7 +3,7 @@
 
 ### **Purpose**
 
-To outline the circumstances under which ESIP would provide for complimentary registrations for ESIP Summer and ESIP Winter Meetings.
+To outline the circumstances under which ESIP would provide for complimentary registrations for ESIP July and ESIP January Meetings.
 
 ### **Policy**
 
@@ -16,7 +16,7 @@ To outline the circumstances under which ESIP would provide for complimentary re
   f. 1 attendee for each Friends of ESIP Level Sponsors at meeting
   g. Organizations that have reciprocal event fee MOUs in place with ESIP
   h. Plenary Speakers
-  i. For ESIP Summer Meeting only, Teachers registered for the concurrent ESIP Teacher’s Workshop. 
+  i. For ESIP July Meeting only, Teachers registered for the concurrent ESIP Teacher’s Workshop. 
   j. Attendees funded under the Finance Committee’s special travel
 2. The Executive Director and President have the authority to not charge registration fees, as circumstances warrant or as deemed in the best interest of ESIP.
 

--- a/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.6 Asset Management Policies.md
+++ b/ESIP Policies and Procedures/3.0 Business and Finance/ESIP P&P 3.6 Asset Management Policies.md
@@ -158,7 +158,7 @@ contributions may be made to the Fund and such gifts shall be subject to the ter
 Fund and will be considered permanent. The annual income from the Fund may be paid out
 partially or in its entirety as scholarships or rolled over for use in a future year or
 any combination thereof. The scholarship will be awarded annually and will provide a
-stipend, travel support to the Earth Science Federation summer meeting and an invited
+stipend, travel support to the Earth Science Federation July meeting and an invited
 talk covering the winner's field of interest.
 
 As required by accounting principles generally accepted in the United

--- a/Standing Committee and Cluster Policies and Procedures/Funding Friday Rules.md
+++ b/Standing Committee and Cluster Policies and Procedures/Funding Friday Rules.md
@@ -5,7 +5,7 @@ FUNding Friday Rules
 Summer 2017
 
 FUNding Friday is an annual mini-grant competition associated with
-ESIP's Summer Meeting.
+ESIP's July Meeting.
 
 The mini-grants are available to ESIP members (\$5000) and to students
 and Education Committee workshop participants (\$3000), with total
@@ -13,7 +13,7 @@ number of awards specified annually and generally 2-4 awards per
 participant group.
 
 Projects are expected to be completed over the six month period between
-the Summer Meeting of the award and the next Winter Meeting.
+the July Meeting of the award and the next January Meeting.
 
 (FUNding Friday will be abbreviated as FF throughout this document.)
 
@@ -34,7 +34,7 @@ Successful projects are:
 3.  Valuable to the ESIP community
 
 Interested participants are encouraged to consider the meeting theme and
-the discussions and activities of the Summer Meeting registrants when
+the discussions and activities of the July Meeting registrants when
 developing a project idea. The competition does not have a single theme
 or topical focus. A list of awarded projects is
 [[available]{.underline}](http://wiki.esipfed.org/index.php/FUNding_Friday_Projects).
@@ -45,8 +45,8 @@ Eligibility and Participation
 ### Eligibility
 
 FF project leads can be ESIP members, student attendees including ESIP
-student fellow, and participants of the Education committee's summer
-meeting workshop. Other meeting attendees are welcome as project
+student fellow, and participants of the Education committee's July
+Meeting workshop. Other meeting attendees are welcome as project
 participants.
 
 Education Committee workshop participants do not need an ESIP member to
@@ -85,7 +85,7 @@ Information for the FUNding Friday awards** below).
 ### How to Participate
 
 Interested participants must exhibit a poster describing the project
-during the Poster Pitch session (Friday morning, check the Summer
+during the Poster Pitch session (Friday morning, check the July
 Meeting schedule for specific time and place). The poster should be hung
 in the provided space before the pitch session begins.
 
@@ -108,7 +108,7 @@ Poster Pitch session.
 
 You must be present at the Poster Pitch session to vote.
 
-Anyone who is a registrant of the Summer Meeting, i.e. anyone with a
+Anyone who is a registrant of the July Meeting, i.e. anyone with a
 badge, is eligible to vote.
 
 Each person attending the Poster Pitch session (Friday morning) will
@@ -123,7 +123,7 @@ flip a coin to determine the winner. In the case of a three (or more)
 way tie, the winner of the tie will be determined by a vote of the ESIP
 Programming Committee at the next scheduled telecon.
 
-The winners will be announced during lunch (refer to the Summer Meeting
+The winners will be announced during lunch (refer to the July Meeting
 schedule for details). Participants do not need to be present at the
 award announcement; however, the project lead should verify that their
 contact information is correct with ESIP staff immediately following the
@@ -141,12 +141,12 @@ The awards are distributed in two parts:
 
 1.  Half once a Memorandum of Understanding (MOU), containing a
     > statement of work, is delivered to ESIP staff at the start of the
-    > project after the Summer Meeting;
+    > project after the July Meeting;
 
-2.  Half following the next Winter Meeting after the results of the
+2.  Half following the next January Meeting after the results of the
     > project are presented during the poster session. All work must be
     > completed at this time. Awardees may present their projects in a
-    > relevant session at the Winter Meeting but must present a poster.
+    > relevant session at the January Meeting but must present a poster.
 
 Note that funding is not immediately disbursed - awardees should account
 for the time needed to draft the MOU and ESIP staff response.

--- a/Standing Committee and Cluster Policies and Procedures/Raskin Scholarship Procedure.md
+++ b/Standing Committee and Cluster Policies and Procedures/Raskin Scholarship Procedure.md
@@ -13,7 +13,7 @@
 
 -   Physical award ordered
 
--   Summer Meeting Presentation at ESIP meeting
+-   July Meeting Presentation at ESIP meeting
 
 **Email announcement: **
 
@@ -96,14 +96,14 @@ selected the winner, I would like to congratulate you on being selected
 as our [[2017 Raskin
 Scholar]{.underline}](http://esipfed.org/raskinscholarship)! The
 committee was very impressed with your work and we are looking forward
-to meeting you at the [[Summer ESIP
+to meeting you at the [[July ESIP
 meeting]{.underline}](http://www.esipfed.org/meetings/upcoming-meetings/esip-summer-meeting-2017),
 July 25-28, 2017 at Indiana University in Bloomington, IN. Your travel
 will be covered as part of the award. **
 
 **Attached please find the official correspondence from Emily Law, ESIP
 President, and myself, about the award. Please confirm that you are able
-to receive this award and participate in the summer meeting. In
+to receive this award and participate in the July meeting. In
 addition, if you could send staff@esipfed.org a quick bio, we will be
 sharing a press release once we have confirmation from you. **
 


### PR DESCRIPTION
* Replace "summer" with July and "winter" with January when referencing annual ESIP meetings.
* Change made throughout ESIP Policies and Procedures documents.
* Also made changes in the "Standing Committee and Cluster" P&P documents
* Should partially address issue #24 