### PR TITLE
Remove Integrity Counts

### DIFF
--- a/ESIP Policies and Procedures/2.0 Ethics and Conduct/ESIP P&P 2.1 Community Participation Guidelines.md
+++ b/ESIP Policies and Procedures/2.0 Ethics and Conduct/ESIP P&P 2.1 Community Participation Guidelines.md
@@ -199,16 +199,14 @@ We encourage you to report incidents where someone has engaged in behavior that 
 
 If you experience or witness unacceptable behavior, you may ask the person to stop their unacceptable behavior. You should also contact relevant authorities (for example, event security, emergency medical services) as you feel necessary. However, you are not obligated to take these actions prior to making a report to ESIP.
 
-ESIP has engaged a third-party reporting service, [IntegrityCounts](https://www.integritycounts.ca/). This is a private, confidential, and optionally anonymous reporting system, meant to encourage reporting without fear of retaliation and afford transparency in the process by providing an independent record. Note that it is possible to make an anonymous report and to exclude certain individuals from the process.
+ESIP has an online reporting form to file a report. This form is submitted to the ESIP Executive Director, Operations Director, and President. Should you wish to exclude one or more of these people from the report, email is the best method of first report. ESIP staff email addresses can be found at: [https://www.esipfed.org/about/people/#](https://www.esipfed.org/about/people/#) and the ESIP President can be reached at [President@esipfed.org](mailto://President@esipfed.org). It is also possible to make an anonymous report. Anonymous reporting limits ESIP’s ability to follow-up on the status of the report, but we encourage anonymous reporting over not reporting so we can address issues that occur.
 
-If you believe you have experienced or are experiencing unacceptable behavior as outlined in [Section 3](https://github.com/ESIPFed/Governance/blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P&P%202.1%20Community%20Participation%20Guidelines.md#section-3----behaviors-that-will-not-be-tolerated), please use one of the following methods of reporting to ESIP via IntegrityCounts:
+If you believe you have experienced or are experiencing unacceptable behavior as outlined in [Section 3](https://github.com/ESIPFed/Governance/blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P&P%202.1%20Community%20Participation%20Guidelines.md#section-3----behaviors-that-will-not-be-tolerated), please use one of the following methods of reporting to ESIP:
 
 
-   **Web:** https://www.integritycounts.ca/org/esip
+   **Web:** <<reporting form>>
 
-   **Toll Free Number:** 1-866-921-6714
-
-   **Email:** esip@integritycounts.ca
+   **Toll Free Number:** 1-800-881-9418 select Executive Director or Operations Director
 
 Additional details on this process can be found [here](https://github.com/ESIPFed/Governance/blob/master/Standing%20Committee%20and%20Cluster%20Policies%20and%20Procedures/Community%20Participation%20Guidelines%20(CPG)%20Reporting%20-%20Additional%20Information.md).
 

--- a/Standing Committee and Cluster Policies and Procedures/Community Participation Guidelines (CPG) Reporting - Additional Information.md
+++ b/Standing Committee and Cluster Policies and Procedures/Community Participation Guidelines (CPG) Reporting - Additional Information.md
@@ -19,15 +19,9 @@ discuss the incident and, if appropriate, make a report yourself or via a [proxy
 ### **Direct reporting**
 
 Individuals who experience or witness unacceptable behaviors in all ESIP activities ([CPG
-Section 1](https://github.com/ESIPFed/Governance/blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P&P%202.1%20Community%20Participation%20Guidelines.md#section-1----when-to-use-these-guidelines)) are encouraged to make a report directly through Integrity Counts ([CPG Section 5](https://github.com/ESIPFed/Governance/blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P&P%202.1%20Community%20Participation%20Guidelines.md#section-5----reporting)).
-They can optionally identify themselves in the report, to enable any necessary follow-ups.
+Section 1](https://github.com/ESIPFed/Governance/blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P&P%202.1%20Community%20Participation%20Guidelines.md#section-1----when-to-use-these-guidelines)) are encouraged to make a report directly through the online reporting form ([CPG Section 5](https://github.com/ESIPFed/Governance/blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P&P%202.1%20Community%20Participation%20Guidelines.md#section-5----reporting)).
+Anonymous reports are allowed but will limit the ability for follow-up.
 
-The reporting process through Integrity Counts is confidential. You have the option to be (1)
-known to all involved in the process (i.e., you provide your contact information), (2) known to
-Integrity Counts but anonymous (i.e., your contact information is not provided) to ESIP or
-specific individuals within ESIP (by role or name), or (3) strictly anonymous. While the latter
-“anonymous” may limit the ability to follow up with you, it is important that unacceptable
-behavior is identified, so that patterns can be recognized and addressed.
 
 ### **Proxy reporting**
 
@@ -39,11 +33,12 @@ report yourself, even anonymously, but want the information recorded, you may as
 **What happens after a report is filed**
 ------------------------------------------------
 
-Reports made to Integrity Counts (Web: https://www.integritycounts.ca/org/esip; Toll Free
-Number: 1-866-921-6714; Email: esip@integritycounts.ca) are shared with ESIP’s Executive
+Reports made to the online reporting form (Web: <<form to come>>; Toll Free
+Number: 800-881-9418 (choose extension for Executive Director or Operations Director); are shared with ESIP’s Executive
 Director, Operations Director, and President, and, optionally, additional review committee
 members that may include the Governance Chair and the Vice-President. Reporters may elect
-to exclude one or more of these individuals from viewing the report.
+to exclude one or more of these individuals from viewing the report by reporting via phone or email directly to the ESIP Executive Director, Operations Director or President.
+
 
 Upon receiving a complaint from a community member, the complaint will be assessed for
 severity and violation of the Community Participation Guidelines, and all parties will be notified
@@ -65,7 +60,7 @@ notified of any such disclosure.
 ### **Correspondence**
 
 All reports are reviewed and responded to based on the nature of the report. ESIP will provide
-reasonably prompt updates via Integrity Counts.
+reasonably prompt updates via email.
 
 ### **Redress**
 


### PR DESCRIPTION
The ESIP leadership have created a process that retains most of the benefits of using a third party reporting service without the costs. This PR reflect changes suggested by Susan