### PR TITLE
Remove individuals' names from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Governance
-This repository holds the ESIP Governance documents. The repository is maintained by the ESIP Governance Committee, chaired by Denise Hills. For all details on ESIP Governance activities see the wiki: http://wiki.esipfed.org/index.php/Constitution_and_Bylaws
+This repository holds the ESIP Governance documents. The repository is maintained by the ESIP Governance Committee, who can be reached 
+at [governance@esipfed.org](mailto://governance@esipfed.org) or by raising 
+a [GitHub issue](https://github.com/ESIPFed/Governance/issues/new/choose) in this repository.
+
+For all details on ESIP Governance activities see the wiki: http://wiki.esipfed.org/index.php/Constitution_and_Bylaws
 
 [![DOI](https://zenodo.org/badge/41741549.svg)](https://zenodo.org/badge/latestdoi/41741549)


### PR DESCRIPTION
This will avoid the need to update then site on every leadership change.