### PR TITLE
Fix dead link to Policy 2.2 in Martha Maiden Award Procedures

### DIFF
--- a/procedures/martha-maiden-award.qmd
+++ b/procedures/martha-maiden-award.qmd
@@ -31,7 +31,7 @@ This award honors individuals who have demonstrated leadership, dedication and a
     - Four (4) additional committee members, solicited by the Chair, who should be mindful of maintaining diversity of Partner Type, career stage, gender, and/or other criteria.
     - Approved by the Program Committee.
 5. Award determination shall follow this process:
-    - The Chair will ask committee members to declare any potential conflicts of interest as defined in [Policy and Procedure 2.2](.../blob/master/ESIP%20Policies%20and%20Procedures/2.0%20Ethics%20and%20Conduct/ESIP%20P%26P%202.2%20Conflict%20Of%20Interest.md).
+    - The Chair will ask committee members to declare any potential conflicts of interest as defined in [Policy and Procedure 2.2](../policies/2-ethics-conduct/2-2-conflict-of-interest.qmd).
          - If a committee member declares a potential conflict of interest, a determination will be made by the remaining committee members as to what action is necessary, for example, removal from discussion about a specific nominee or removal from the committee.
          - If a committee member needs to be replaced, a replacement will be determined by the remaining committee members, following the guidelines above.
     - Committee members will submit a ranking of the nominees to the Chair, utilizing a rubric provided by the Chair for guidance, by a date established by the Chair in line with the timeline set by the Executive Director and staff.

--- a/procedures/martha-maiden-award.qmd
+++ b/procedures/martha-maiden-award.qmd
@@ -17,7 +17,7 @@ This award honors individuals who have demonstrated leadership, dedication and a
 ------------------------------------
 
 1. Nominations for awards may come from members of Partner organizations, or of organizations external to ESIP.
-2. Nominations should be submitted electronically via [a web form](https://www.esipfed.org/get-involved/peer-recognition/martha-maiden-award/martha-maiden-nomination-form), and include:
+2. Nominations should be submitted electronically via the web form on the [Martha Maiden Award page](https://www.esipfed.org/awards/martha-maiden-award/#single_column_content-3), and include:
     * Nominating Letter
     * Curriculum Vitae
     * Biography (1 page)


### PR DESCRIPTION
## Summary
- `procedures/martha-maiden-award.qmd` linked to Policy 2.2 (Conflict of Interest) using the old GitHub blob path from the source Markdown, which 404s on the Quarto site
- Replaced with a relative link to the rendered policy page, matching the convention used elsewhere in the repo (e.g. `index.qmd`, `policies/index.qmd`)

## Test plan
- [x] Rendered `procedures/martha-maiden-award.qmd` with `quarto render` and confirmed the link resolves to `../policies/2-ethics-conduct/2-2-conflict-of-interest.html`
- [x] Rendered `policies/2-ethics-conduct/2-2-conflict-of-interest.qmd` and confirmed the target file is produced at that path

Fixes #55