### PR TITLE
Fix missing blank lines that mess up headers in 1.9 Data Privacy Policy

### DIFF
--- a/policies/1-corporate/1-9-data-privacy.qmd
+++ b/policies/1-corporate/1-9-data-privacy.qmd
@@ -21,24 +21,26 @@ For people participating in ESIP partnerships, meetings, newsletter subscription
 ***2.1.1. IMAGES AND PHOTOGRAPHY***
 
 During ESIP events, staff or participants may gather screen captures and at some in-person events a photographer may take photographs. For all ESIP Meetings, participants are asked during registration to give consent for recording and photo release.
+
 #### 2.2. COOKIES
-A “cookie” is a file that a website stores in a user’s computer for future reference. Individuals may set their browsers to reject cookies; however, there are ESIP services that will not fully function unless the user accepts the ESIP cookie. For example, when a user returns to that ESIP service, the cookie will identify the user as a previous visitor. Information supplied through an ESIP cookie is used only by ESIP to help enhance services provided and is not shared with others. 
+A “cookie” is a file that a website stores in a user’s computer for future reference. Individuals may set their browsers to reject cookies; however, there are ESIP services that will not fully function unless the user accepts the ESIP cookie. For example, when a user returns to that ESIP service, the cookie will identify the user as a previous visitor. Information supplied through an ESIP cookie is used only by ESIP to help enhance services provided and is not shared with others.
 
 Web “beacons” are transparent pixel images embedded at certain points on websites that are used to collect information about how users navigate and use the website for the purpose of understanding and improving the function of the site and the value of the content. ESIP uses cookies or other trackers to improve some of its services, provide enhanced functionality on the site, and to aggregate traffic data (i.e., what pages are most popular).
 
 “Cookies” and “beacons” may also be utilized by the third parties that we contract with to provide certain functions. You may block or disable cookies or other trackers by changing the settings on your browser, but doing so may prevent you from accessing certain functionalities on the Sites.
+
 #### 2.3. WEBSITE ANALYTICS
-ESIP gathers web traffic through a third-party service, Google Analytics as well as email marketing, event planning, and social media analytics through other platforms. All information is aggregated and is not personally identifiable. On the ESIPfed.org website we use WordPress plugins to enable acknowledgement of the use of cookies. Users can choose to accept or withhold certain information from Google Analytics in this way. 
+ESIP gathers web traffic through a third-party service, Google Analytics as well as email marketing, event planning, and social media analytics through other platforms. All information is aggregated and is not personally identifiable. On the ESIPfed.org website we use WordPress plugins to enable acknowledgement of the use of cookies. Users can choose to accept or withhold certain information from Google Analytics in this way.
 
 ### 3. USE OF INFORMATION
-Once collected, ESIP may use information in a variety of ways including: 
+Once collected, ESIP may use information in a variety of ways including:
 
 - To communicate with you about your ESIP participation, if applicable, or to communicate information about ESIP. For example, we may send all new users a registration e-mail, and we will also occasionally send important notices or information.
-- To provide you with prompt and effective customer service. 
-- To fulfill and/or deliver products and services as meeting registration, submission of articles, administer awards and honors, and in various other interactions. 
-- To build higher-quality, more useful services,such as by analyzing usage trends, and by measuring demographics and interests regarding specific areas of the Sites. 
-- To conduct internal assessments of ESIP programs and membership; additionally, these data, in an aggregated form, may be used in publicly distributed statistical descriptions and studies of ESIP. 
-- To help us understand membership trends, and demographic differences with respect to perspectives about and usage of programs and the creation of new program offerings. 
+- To provide you with prompt and effective customer service.
+- To fulfill and/or deliver products and services as meeting registration, submission of articles, administer awards and honors, and in various other interactions.
+- To build higher-quality, more useful services,such as by analyzing usage trends, and by measuring demographics and interests regarding specific areas of the Sites.
+- To conduct internal assessments of ESIP programs and membership; additionally, these data, in an aggregated form, may be used in publicly distributed statistical descriptions and studies of ESIP.
+- To help us understand membership trends, and demographic differences with respect to perspectives about and usage of programs and the creation of new program offerings.
 
 #### 3.1. COMMUNITY DATABASE
 Personal and contact information collected through partnerships, meetings, newsletter subscriptions, and other activities, will be stored in the ESIP community database. The database is managed by and accessible to ESIP staff. Individuals will be able to access their own profile. Voting representatives from the ESIP Partner Assembly will be able to update information in organization profiles.
@@ -52,10 +54,10 @@ If you choose to provide us with personal information, through such methods as c
 
 Remember that email isn't necessarily secure. You should never send sensitive or personal information like your Social Security number in an email. Use postal mail or secure Web sites instead.
 
-#### 3.3. OTHER TECHNOLOGIES 
-ESIP may share information with private organizations as part of a service that provides ESIP users with increased capabilities or functionality. ESIP is not responsible for the retention and disposal of information that is held by third parties. ESIP reviews the data policies of other technologies used, to verify that they do not share or sell any data collected from ESIP with any third party.  
+#### 3.3. OTHER TECHNOLOGIES
+ESIP may share information with private organizations as part of a service that provides ESIP users with increased capabilities or functionality. ESIP is not responsible for the retention and disposal of information that is held by third parties. ESIP reviews the data policies of other technologies used, to verify that they do not share or sell any data collected from ESIP with any third party.
 
-### 4. CHILDREN 
+### 4. CHILDREN
 ESIP services and benefits are not designed for minors and we do not knowingly attempt to solicit or receive any information from children. To the extent that minors under the age of 13 do use the Site and ESIP is able to determine the age of web site users - by their submissions to, or communications with ESIP web sites - ESIP will not knowingly collect information from such minors without their parent’s or guardian’s verifiable consent.
 
 ### 5. GOVERNANCE
@@ -63,14 +65,14 @@ Every ESIP officer, volunteer, member of staff, and member who has access to dat
 
 This notice and our privacy practices are exclusively subject to the laws of the District of Columbia and the state of Maryland within the United States of America, without regard to its conflict of laws doctrine.  By using the Site, you irrevocably submit to the exclusive jurisdiction of the courts of the District of Columbia and the state of Maryland for any claim or matters arising under or in connection with the Site.
 
-#### 5.1 OPT IN/OPT OUT 
-ESIP reserves the right to offer either an opt-in or opt-out option depending on the situation and the type of information being collected. Any individual may decline to provide information requested by ESIP. In this case, ESIP may be unable to provide services for which such information is needed for security and/or identification purposes. 
+#### 5.1 OPT IN/OPT OUT
+ESIP reserves the right to offer either an opt-in or opt-out option depending on the situation and the type of information being collected. Any individual may decline to provide information requested by ESIP. In this case, ESIP may be unable to provide services for which such information is needed for security and/or identification purposes.
 
 #### 5.2. ACCESS TO INFORMATION AND ABILITY TO CORRECT DATA
-Upon request via postal mail, email, or telephone, ESIP will provide Members or users with a summary of any personally identifiable information retained by ESIP regarding the Member or user. Subscribers to any ESIP online service can stop service or modify, correct, change, or update personally identifiable information via the Site or by sending an e-mail message to staff@esip.org. Members or users may also initiate the removal of their personal record from the ESIP database by contacting ESIP at staff@esip.org. 
+Upon request via postal mail, email, or telephone, ESIP will provide Members or users with a summary of any personally identifiable information retained by ESIP regarding the Member or user. Subscribers to any ESIP online service can stop service or modify, correct, change, or update personally identifiable information via the Site or by sending an e-mail message to staff@esip.org. Members or users may also initiate the removal of their personal record from the ESIP database by contacting ESIP at staff@esip.org.
 
-#### 5.3. CHANGES TO POLICY 
-ESIP Governance will review the policy annually and reserves the right to change this Privacy Policy at any time. ESIP community members will be notified of significant policy changes via the ESIP newsletter and members are encouraged to regularly review the Policy online. 
+#### 5.3. CHANGES TO POLICY
+ESIP Governance will review the policy annually and reserves the right to change this Privacy Policy at any time. ESIP community members will be notified of significant policy changes via the ESIP newsletter and members are encouraged to regularly review the Policy online.
 
 ### 6. DISCLAIMER AND LIMITATION OF LIABILITY
 ESIP makes no representations, warranties, or assurances as to the accuracy, currency or completeness of the content contained on this Site. All the materials on this site are provided “as is” without any express or implied warranty of any kind, including warranties of merchantability, noninfringement of intellectual property or fitness for any particular purpose. In no event shall ESIP or its agents or associates be liable for any damages whatsoever (including, without limitation, damages for loss of profits, business interruption, loss of information, injury or death) arising out of the use of or inability to use the materials, even if it has been advised of the possibility of such loss or damages.
@@ -80,7 +82,7 @@ ESIP links to many Websites created and maintained by other public and/or privat
 When users follow a link to an outside Website, they are leaving ESIP and are subject to the privacy and security policies of the owners/sponsors of the outside Website(s). ESIP is not responsible for the information collection practices of non-ESIP sites.
 
 ### 7. QUESTIONS AND CONTACT
-For questions concerning this Privacy policy and management of your individual data please contact staff@esipfed.org. 
+For questions concerning this Privacy policy and management of your individual data please contact staff@esipfed.org.
 
 
 This Policy was approved by the Board of Director on January 11th 2023.


### PR DESCRIPTION
Missing blank lines before section headers prevent rendering correctly. The editor I use also fixed some extra spaces at the end of lines.

Fixes #57 